### PR TITLE
Normalize function

### DIFF
--- a/normalize_url.go
+++ b/normalize_url.go
@@ -1,4 +1,3 @@
-
 package main
 
 import (

--- a/normalize_url.go
+++ b/normalize_url.go
@@ -1,0 +1,7 @@
+package main
+
+// normalizeURL takes a URL string and returns its normalized form.
+func normalizeURL(rawURL string) (string, error) {
+	// TODO: implement normalization logic
+	return "", nil
+}

--- a/normalize_url.go
+++ b/normalize_url.go
@@ -1,7 +1,27 @@
+
 package main
+
+import (
+	"net/url"
+	"strings"
+)
 
 // normalizeURL takes a URL string and returns its normalized form.
 func normalizeURL(rawURL string) (string, error) {
-	// TODO: implement normalization logic
-	return "", nil
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+
+	host := strings.TrimPrefix(u.Hostname(), "www.")
+
+	path := strings.TrimSuffix(u.EscapedPath(), "/")
+
+	// Rebuild normalized URL: host + path
+	normalized := host
+	if path != "" {
+		normalized += path
+	}
+
+	return normalized, nil
 }

--- a/normalize_url.go
+++ b/normalize_url.go
@@ -14,7 +14,7 @@ func normalizeURL(rawURL string) (string, error) {
 
 	host := strings.TrimPrefix(u.Hostname(), "www.")
 
-	path := strings.TrimSuffix(u.EscapedPath(), "/")
+	path := strings.TrimSuffix(u.Path, "/")
 
 	// Rebuild normalized URL: host + path
 	normalized := host

--- a/normalize_url_test.go
+++ b/normalize_url_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestNormalizeURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		inputURL string
+		expected string
+	}{
+		{
+			name:     "remove scheme",
+			inputURL: "https://blog.boot.dev/path",
+			expected: "blog.boot.dev/path",
+		},
+		{
+			name:     "remove http scheme",
+			inputURL: "http://example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "remove trailing slash",
+			inputURL: "https://example.com/",
+			expected: "example.com",
+		},
+		{
+			name:     "keep path",
+			inputURL: "https://example.com/foo/bar",
+			expected: "example.com/foo/bar",
+		},
+		{
+			name:     "remove www",
+			inputURL: "https://www.example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "remove query",
+			inputURL: "https://example.com/path?query=1",
+			expected: "example.com/path",
+		},
+		{
+			name:     "remove fragment",
+			inputURL: "https://example.com/path#section",
+			expected: "example.com/path",
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := normalizeURL(tc.inputURL)
+			if err != nil {
+				t.Errorf("Test %v - '%s' FAIL: unexpected error: %v", i, tc.name, err)
+				return
+			}
+			if actual != tc.expected {
+				t.Errorf("Test %v - %s FAIL: expected URL: %v, actual: %v", i, tc.name, tc.expected, actual)
+			}
+		})
+	}
+}

--- a/normalize_url_test.go
+++ b/normalize_url_test.go
@@ -51,7 +51,7 @@ func TestNormalizeURL(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := normalizeURL(tc.inputURL)
 			if err != nil {
-				t.Errorf("Test %v - '%s' FAIL: unexpected error: %v", i, tc.name, err)
+				t.Errorf("Test %v - %s FAIL: unexpected error: %v", i, tc.name, err)
 				return
 			}
 			if actual != tc.expected {


### PR DESCRIPTION
This pull request introduces a new URL normalization utility in Go, along with a comprehensive suite of unit tests to verify its correctness. The main changes include the implementation of the `normalizeURL` function and a new test file covering various normalization scenarios.

URL normalization utility:

* Added a new file `normalize_url.go` containing the `normalizeURL` function, which parses a URL string and normalizes it by removing the scheme, stripping "www." from the hostname, removing trailing slashes, and discarding query parameters and fragments.

Testing:

* Added `normalize_url_test.go` with multiple test cases to ensure `normalizeURL` behaves correctly for different input URLs, including cases for removing the scheme, "www." prefix, trailing slashes, query parameters, fragments, and preserving the path.