### PR TITLE
Implement getURLsFromHTML function with unit tests

### DIFF
--- a/get_urls_from_html.go
+++ b/get_urls_from_html.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"golang.org/x/net/html"
+	"net/url"
+	"strings"
+)
+
+// getURLsFromHTML extracts all URLs from anchor tags in the HTML and converts relative URLs to absolute using rawBaseURL.
+func getURLsFromHTML(htmlBody, rawBaseURL string) ([]string, error) {
+	var urls []string
+	base, err := url.Parse(rawBaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	doc, err := html.Parse(strings.NewReader(htmlBody))
+	if err != nil {
+		return nil, err
+	}
+
+	var traverse func(*html.Node)
+	traverse = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			for _, attr := range n.Attr {
+				if attr.Key == "href" {
+					href := attr.Val
+					u, err := url.Parse(href)
+					if err == nil {
+						resolved := base.ResolveReference(u)
+						urls = append(urls, resolved.String())
+					}
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			traverse(c)
+		}
+	}
+	traverse(doc)
+
+	return urls, nil
+}

--- a/get_urls_from_html.go
+++ b/get_urls_from_html.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"golang.org/x/net/html"
 	"net/url"
 	"strings"
+
+	"golang.org/x/net/html"
 )
 
 // getURLsFromHTML extracts all URLs from anchor tags in the HTML and converts relative URLs to absolute using rawBaseURL.
@@ -26,7 +27,11 @@ func getURLsFromHTML(htmlBody, rawBaseURL string) ([]string, error) {
 				if attr.Key == "href" {
 					href := attr.Val
 					u, err := url.Parse(href)
-					if err == nil {
+					if err != nil {
+						// If parsing fails, try to resolve it as-is relative to base
+						resolved := base.String() + href
+						urls = append(urls, resolved)
+					} else {
 						resolved := base.ResolveReference(u)
 						urls = append(urls, resolved.String())
 					}

--- a/get_urls_from_html.go
+++ b/get_urls_from_html.go
@@ -26,15 +26,20 @@ func getURLsFromHTML(htmlBody, rawBaseURL string) ([]string, error) {
 			for _, attr := range n.Attr {
 				if attr.Key == "href" {
 					href := attr.Val
+					// Skip empty hrefs
+					if href == "" {
+						resolved := base.ResolveReference(&url.URL{})
+						urls = append(urls, resolved.String())
+						continue
+					}
+					
 					u, err := url.Parse(href)
 					if err != nil {
-						// If parsing fails, try to resolve it as-is relative to base
-						resolved := base.String() + href
-						urls = append(urls, resolved)
-					} else {
-						resolved := base.ResolveReference(u)
-						urls = append(urls, resolved.String())
+						// Skip malformed URLs rather than creating invalid ones
+						continue
 					}
+					resolved := base.ResolveReference(u)
+					urls = append(urls, resolved.String())
 				}
 			}
 		}

--- a/get_urls_from_html_test.go
+++ b/get_urls_from_html_test.go
@@ -88,7 +88,7 @@ func TestGetURLsFromHTML(t *testing.T) {
 	</body>
 </html>
 `,
-			expected: []string{"https://malformed.com://bad:url"},
+			expected: []string{},
 		},
 	}
 

--- a/get_urls_from_html_test.go
+++ b/get_urls_from_html_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetURLsFromHTML(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputURL  string
+		inputBody string
+		expected  []string
+	}{
+		{
+			name:     "absolute and relative URLs",
+			inputURL: "https://blog.boot.dev",
+			inputBody: `
+<html>
+	<body>
+		<a href="/path/one">
+			<span>Boot.dev</span>
+		</a>
+		<a href="https://other.com/path/one">
+			<span>Boot.dev</span>
+		</a>
+	</body>
+</html>
+`,
+			expected: []string{"https://blog.boot.dev/path/one", "https://other.com/path/one"},
+		},
+		{
+			name:     "multiple relative URLs",
+			inputURL: "https://example.com",
+			inputBody: `
+<html>
+	<body>
+		<a href="/foo">foo</a>
+		<a href="/bar">bar</a>
+	</body>
+</html>
+`,
+			expected: []string{"https://example.com/foo", "https://example.com/bar"},
+		},
+		{
+			name:     "no anchor tags",
+			inputURL: "https://none.com",
+			inputBody: `
+<html>
+	<body>
+		<p>No links here!</p>
+	</body>
+</html>
+`,
+			expected: []string{},
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := getURLsFromHTML(tc.inputBody, tc.inputURL)
+			if err != nil {
+				t.Errorf("Test %v - '%s' FAIL: unexpected error: %v", i, tc.name, err)
+				return
+			}
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("Test %v - %s FAIL: expected URLs: %v, actual: %v", i, tc.name, tc.expected, actual)
+			}
+		})
+	}
+}

--- a/get_urls_from_html_test.go
+++ b/get_urls_from_html_test.go
@@ -54,6 +54,42 @@ func TestGetURLsFromHTML(t *testing.T) {
 `,
 			expected: []string{},
 		},
+		{
+			name:     "anchor with no href",
+			inputURL: "https://nohref.com",
+			inputBody: `
+<html>
+	<body>
+		<a>no href</a>
+	</body>
+</html>
+`,
+			expected: []string{},
+		},
+		{
+			name:     "anchor with empty href",
+			inputURL: "https://emptyhref.com",
+			inputBody: `
+<html>
+	<body>
+		<a href="">empty href</a>
+	</body>
+</html>
+`,
+			expected: []string{"https://emptyhref.com"},
+		},
+		{
+			name:     "anchor with invalid href",
+			inputURL: "https://malformed.com",
+			inputBody: `
+<html>
+	<body>
+		<a href="://bad:url">bad url</a>
+	</body>
+</html>
+`,
+			expected: []string{"https://malformed.com://bad:url"},
+		},
 	}
 
 	for i, tc := range tests {
@@ -61,6 +97,10 @@ func TestGetURLsFromHTML(t *testing.T) {
 			actual, err := getURLsFromHTML(tc.inputBody, tc.inputURL)
 			if err != nil {
 				t.Errorf("Test %v - '%s' FAIL: unexpected error: %v", i, tc.name, err)
+				return
+			}
+			if len(actual) == 0 && len(tc.expected) == 0 {
+				// Both are empty, this is a pass
 				return
 			}
 			if !reflect.DeepEqual(actual, tc.expected) {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/see-why/Crawler
 
 go 1.24.3
 
-require golang.org/x/net v0.43.0 // indirect
+require golang.org/x/net v0.43.0

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/see-why/Crawler
 
 go 1.24.3
+
+require golang.org/x/net v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
+golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=


### PR DESCRIPTION
Add the `getURLsFromHTML` function to extract and resolve URLs from HTML anchor tags. Include unit tests to validate functionality and cover various edge cases. Update dependencies to include `golang.org/x/net`.