### PR TITLE
Crawl recursively

### DIFF
--- a/crawl_page.go
+++ b/crawl_page.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"net/url"
-	"strings"
 	"sync"
 )
 
@@ -47,7 +46,7 @@ func (cfg *config) crawlPage(rawCurrentURL string) {
 	}
 
 	// Check if current URL is on the same domain as base URL
-	if !strings.EqualFold(currentURL.Hostname(), cfg.baseURL.Hostname()) {
+	if currentURL.Hostname() != cfg.baseURL.Hostname() {
 		return
 	}
 

--- a/crawl_page.go
+++ b/crawl_page.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// crawlPage recursively crawls pages starting from rawCurrentURL, staying within the same domain as rawBaseURL
+func crawlPage(rawBaseURL, rawCurrentURL string, pages map[string]int) {
+	// Parse the base URL and current URL to compare domains
+	baseURL, err := url.Parse(rawBaseURL)
+	if err != nil {
+		fmt.Printf("Error parsing base URL %s: %v\n", rawBaseURL, err)
+		return
+	}
+
+	currentURL, err := url.Parse(rawCurrentURL)
+	if err != nil {
+		fmt.Printf("Error parsing current URL %s: %v\n", rawCurrentURL, err)
+		return
+	}
+
+	// Check if current URL is on the same domain as base URL
+	if !strings.EqualFold(currentURL.Hostname(), baseURL.Hostname()) {
+		return
+	}
+
+	// Get normalized version of the current URL
+	normalizedURL, err := normalizeURL(rawCurrentURL)
+	if err != nil {
+		fmt.Printf("Error normalizing URL %s: %v\n", rawCurrentURL, err)
+		return
+	}
+
+	// Check if we've already crawled this page
+	if count, exists := pages[normalizedURL]; exists {
+		pages[normalizedURL] = count + 1
+		return
+	}
+
+	// Add this page to our map
+	pages[normalizedURL] = 1
+
+	// Print what we're crawling
+	fmt.Printf("Crawling: %s\n", rawCurrentURL)
+
+	// Get the HTML from the current URL
+	htmlBody, err := getHTML(rawCurrentURL)
+	if err != nil {
+		fmt.Printf("Error getting HTML from %s: %v\n", rawCurrentURL, err)
+		return
+	}
+
+	// Get all URLs from the HTML
+	urls, err := getURLsFromHTML(htmlBody, rawBaseURL)
+	if err != nil {
+		fmt.Printf("Error getting URLs from HTML of %s: %v\n", rawCurrentURL, err)
+		return
+	}
+
+	// Recursively crawl each URL found on the page
+	for _, foundURL := range urls {
+		crawlPage(rawBaseURL, foundURL, pages)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -23,12 +23,15 @@ func main() {
 	baseURL := args[0]
 	fmt.Printf("starting crawl of: %s\n", baseURL)
 
-	// Fetch HTML from the base URL
-	html, err := getHTML(baseURL)
-	if err != nil {
-		fmt.Printf("Error fetching HTML: %v\n", err)
-		os.Exit(1)
-	}
+	// Initialize the pages map to track crawled pages
+	pages := make(map[string]int)
 
-	fmt.Println(html)
+	// Start crawling from the base URL
+	crawlPage(baseURL, baseURL, pages)
+
+	// Print the results
+	fmt.Println("\n=== Crawl Results ===")
+	for url, count := range pages {
+		fmt.Printf("%s: %d\n", url, count)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"sync"
 )
 
@@ -12,18 +13,52 @@ func main() {
 	args := os.Args[1:]
 
 	if len(args) < 1 {
-		fmt.Println("no website provided")
+		fmt.Println("Usage: crawler <URL> [max_concurrency]")
+		fmt.Println("  URL: The website URL to crawl")
+		fmt.Println("  max_concurrency: Maximum number of concurrent goroutines (default: 10)")
+		fmt.Println("  Environment variable CRAWLER_MAX_CONCURRENCY can also be used")
 		os.Exit(1)
 	}
 
-	if len(args) > 1 {
+	if len(args) > 2 {
 		fmt.Println("too many arguments provided")
+		fmt.Println("Usage: crawler <URL> [max_concurrency]")
 		os.Exit(1)
 	}
 
-	// Exactly one argument - the BASE_URL
+	// First argument - the BASE_URL
 	baseURLString := args[0]
-	fmt.Printf("starting crawl of: %s\n", baseURLString)
+
+	// Second argument or environment variable - maxConcurrency
+	maxConcurrency := 10 // Default value
+
+	// Check if maxConcurrency was provided as command line argument
+	if len(args) == 2 {
+		if parsed, err := strconv.Atoi(args[1]); err != nil {
+			fmt.Printf("Error parsing max_concurrency '%s': %v\n", args[1], err)
+			fmt.Println("max_concurrency must be a positive integer")
+			os.Exit(1)
+		} else if parsed <= 0 {
+			fmt.Println("max_concurrency must be a positive integer")
+			os.Exit(1)
+		} else {
+			maxConcurrency = parsed
+		}
+	} else if envVar := os.Getenv("CRAWLER_MAX_CONCURRENCY"); envVar != "" {
+		// Check environment variable if no command line argument provided
+		if parsed, err := strconv.Atoi(envVar); err != nil {
+			fmt.Printf("Error parsing CRAWLER_MAX_CONCURRENCY '%s': %v\n", envVar, err)
+			fmt.Println("CRAWLER_MAX_CONCURRENCY must be a positive integer")
+			os.Exit(1)
+		} else if parsed <= 0 {
+			fmt.Println("CRAWLER_MAX_CONCURRENCY must be a positive integer")
+			os.Exit(1)
+		} else {
+			maxConcurrency = parsed
+		}
+	}
+
+	fmt.Printf("starting crawl of: %s (max concurrency: %d)\n", baseURLString, maxConcurrency)
 
 	// Parse the base URL
 	baseURL, err := url.Parse(baseURLString)
@@ -33,7 +68,6 @@ func main() {
 	}
 
 	// Initialize the config struct
-	maxConcurrency := 10 // Test with higher concurrency
 	cfg := &config{
 		pages:              make(map[string]int),
 		baseURL:            baseURL,


### PR DESCRIPTION
This pull request refactors the crawling logic to support recursive page crawling within the same domain, and updates the main program flow to utilize this new approach. The most important changes include introducing a new `crawlPage` function for recursive crawling, and updating the main function to use this function and print a summary of crawled pages.

### Crawling logic improvements

* Added a new `crawlPage` function in `crawl_page.go` that recursively crawls pages starting from a base URL, ensuring that only pages within the same domain are visited. The function normalizes URLs, tracks visited pages, and prints each crawled page.

### Main program updates

* Updated the main function in `main.go` to initialize a `pages` map, start the crawl using `crawlPage`, and print a summary of all crawled pages and their visit counts. This replaces the previous logic that only fetched and printed the HTML for the base URL.
This pull request introduces a concurrent web crawler that recursively crawls pages within a given domain, starting from a base URL. The main changes include the addition of a new `config` struct to manage state, the implementation of concurrency control using goroutines and channels, and the refactoring of the main function to use these new components. The crawler tracks visited pages and prints a summary of results at the end.

### Major feature: Concurrent web crawler implementation

* Added `crawl_page.go` with a new `config` struct to manage crawling state, including visited pages, base URL, mutex for thread safety, concurrency control channel, and wait group. (`[crawl_page.goR1-R89](diffhunk://#diff-619d3eb74ab26a5942fe9eb87fa939fcdd6d9a114d002443c285930194d0635aR1-R89)`)
* Implemented the `crawlPage` method in `config` to recursively crawl pages within the same domain, using goroutines for concurrency and safely tracking page visits. (`[crawl_page.goR1-R89](diffhunk://#diff-619d3eb74ab26a5942fe9eb87fa939fcdd6d9a114d002443c285930194d0635aR1-R89)`)
* Refactored `main.go` to initialize the `config` struct, start the crawl using goroutines, and print a summary of visited pages and their counts. (`[main.goL23-R56](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L23-R56)`)
* Added necessary imports for `net/url` and `sync` to support URL parsing and concurrency control. (`[main.goR5-R7](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R5-R7)`)