### PR TITLE
Max pages

### DIFF
--- a/crawl_page.go
+++ b/crawl_page.go
@@ -9,6 +9,7 @@ import (
 type config struct {
 	pages              map[string]int
 	baseURL            *url.URL
+	maxPages           int
 	mu                 *sync.Mutex
 	concurrencyControl chan struct{}
 	wg                 *sync.WaitGroup
@@ -37,6 +38,15 @@ func (cfg *config) crawlPage(rawCurrentURL string) {
 		<-cfg.concurrencyControl
 		cfg.wg.Done()
 	}()
+
+	// Check if we've reached the maximum number of pages
+	cfg.mu.Lock()
+	currentPageCount := len(cfg.pages)
+	cfg.mu.Unlock()
+
+	if currentPageCount >= cfg.maxPages {
+		return
+	}
 
 	// Parse the current URL
 	currentURL, err := url.Parse(rawCurrentURL)

--- a/crawl_page.go
+++ b/crawl_page.go
@@ -21,15 +21,15 @@ func (cfg *config) addPageVisit(normalizedURL string) (isFirst bool, exceedsLimi
 	cfg.mu.Lock()
 	defer cfg.mu.Unlock()
 
-	// Check if we've reached the maximum number of pages before adding
-	if len(cfg.pages) >= cfg.maxPages {
-		return false, true
-	}
-
 	count, exists := cfg.pages[normalizedURL]
 	if exists {
 		cfg.pages[normalizedURL] = count + 1
 		return false, false
+	}
+
+	// Check if we've reached the maximum number of pages before adding a NEW page
+	if len(cfg.pages) >= cfg.maxPages {
+		return false, true
 	}
 
 	cfg.pages[normalizedURL] = 1

--- a/crawl_page.go
+++ b/crawl_page.go
@@ -16,18 +16,24 @@ type config struct {
 }
 
 // addPageVisit safely adds a page visit to the map and returns whether this is the first visit
-func (cfg *config) addPageVisit(normalizedURL string) (isFirst bool) {
+// and whether adding this page would exceed the maxPages limit
+func (cfg *config) addPageVisit(normalizedURL string) (isFirst bool, exceedsLimit bool) {
 	cfg.mu.Lock()
 	defer cfg.mu.Unlock()
+
+	// Check if we've reached the maximum number of pages before adding
+	if len(cfg.pages) >= cfg.maxPages {
+		return false, true
+	}
 
 	count, exists := cfg.pages[normalizedURL]
 	if exists {
 		cfg.pages[normalizedURL] = count + 1
-		return false
+		return false, false
 	}
 
 	cfg.pages[normalizedURL] = 1
-	return true
+	return true, false
 }
 
 // crawlPage recursively crawls pages starting from rawCurrentURL, staying within the same domain as baseURL
@@ -38,15 +44,6 @@ func (cfg *config) crawlPage(rawCurrentURL string) {
 		<-cfg.concurrencyControl
 		cfg.wg.Done()
 	}()
-
-	// Check if we've reached the maximum number of pages
-	cfg.mu.Lock()
-	currentPageCount := len(cfg.pages)
-	cfg.mu.Unlock()
-
-	if currentPageCount >= cfg.maxPages {
-		return
-	}
 
 	// Parse the current URL
 	currentURL, err := url.Parse(rawCurrentURL)
@@ -67,8 +64,11 @@ func (cfg *config) crawlPage(rawCurrentURL string) {
 		return
 	}
 
-	// Check if this is the first visit to this page
-	isFirst := cfg.addPageVisit(normalizedURL)
+	// Atomically check if this is the first visit and if we've reached the page limit
+	isFirst, exceedsLimit := cfg.addPageVisit(normalizedURL)
+	if exceedsLimit {
+		return
+	}
 	if !isFirst {
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -13,16 +13,17 @@ func main() {
 	args := os.Args[1:]
 
 	if len(args) < 1 {
-		fmt.Println("Usage: crawler <URL> [max_concurrency]")
+		fmt.Println("Usage: crawler <URL> [max_concurrency] [max_pages]")
 		fmt.Println("  URL: The website URL to crawl")
 		fmt.Println("  max_concurrency: Maximum number of concurrent goroutines (default: 10)")
+		fmt.Println("  max_pages: Maximum number of pages to crawl (default: 10)")
 		fmt.Println("  Environment variable CRAWLER_MAX_CONCURRENCY can also be used")
 		os.Exit(1)
 	}
 
-	if len(args) > 2 {
+	if len(args) > 3 {
 		fmt.Println("too many arguments provided")
-		fmt.Println("Usage: crawler <URL> [max_concurrency]")
+		fmt.Println("Usage: crawler <URL> [max_concurrency] [max_pages]")
 		os.Exit(1)
 	}
 
@@ -32,8 +33,11 @@ func main() {
 	// Second argument or environment variable - maxConcurrency
 	maxConcurrency := 10 // Default value
 
+	// Third argument - maxPages
+	maxPages := 10 // Default value
+
 	// Check if maxConcurrency was provided as command line argument
-	if len(args) == 2 {
+	if len(args) >= 2 {
 		if parsed, err := strconv.Atoi(args[1]); err != nil {
 			fmt.Printf("Error parsing max_concurrency '%s': %v\n", args[1], err)
 			fmt.Println("max_concurrency must be a positive integer")
@@ -58,7 +62,21 @@ func main() {
 		}
 	}
 
-	fmt.Printf("starting crawl of: %s (max concurrency: %d)\n", baseURLString, maxConcurrency)
+	// Check if maxPages was provided as command line argument
+	if len(args) >= 3 {
+		if parsed, err := strconv.Atoi(args[2]); err != nil {
+			fmt.Printf("Error parsing max_pages '%s': %v\n", args[2], err)
+			fmt.Println("max_pages must be a positive integer")
+			os.Exit(1)
+		} else if parsed <= 0 {
+			fmt.Println("max_pages must be a positive integer")
+			os.Exit(1)
+		} else {
+			maxPages = parsed
+		}
+	}
+
+	fmt.Printf("starting crawl of: %s (max concurrency: %d, max pages: %d)\n", baseURLString, maxConcurrency, maxPages)
 
 	// Parse the base URL
 	baseURL, err := url.Parse(baseURLString)
@@ -71,6 +89,7 @@ func main() {
 	cfg := &config{
 		pages:              make(map[string]int),
 		baseURL:            baseURL,
+		maxPages:           maxPages,
 		mu:                 &sync.Mutex{},
 		concurrencyControl: make(chan struct{}, maxConcurrency),
 		wg:                 &sync.WaitGroup{},


### PR DESCRIPTION
This pull request adds a new feature to the web crawler: the ability to limit the maximum number of pages it crawls. This helps prevent the crawler from running indefinitely or consuming excessive resources. The changes update both the configuration and command-line interface to support this feature.

### New Feature: Maximum Page Limit

* Added a `maxPages` field to the `config` struct in `crawl_page.go` to track the maximum number of pages to crawl.
* Implemented a check in `crawlPage` to stop crawling when the number of crawled pages reaches `maxPages`.

### CLI and Configuration Updates

* Updated the usage message in `main.go` to include the new `[max_pages]` argument and improved error handling for argument count.
* Added parsing logic in `main.go` to read `maxPages` from the command line, with validation for positive integer values. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R36-R40) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L61-R79)
* Passed the `maxPages` value into the `config` struct when initializing the crawler in `main.go`.