### PR TITLE
Refactor printReport function to improve sorting and output format of…

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,11 +22,18 @@ func printReport(pages map[string]int, baseURL string) {
 	fmt.Printf("  REPORT for %s\n", baseURL)
 	fmt.Println("=============================")
 
+	// Parse the baseURL to get the original scheme
+	parsedBaseURL, err := url.Parse(baseURL)
+	if err != nil {
+		fmt.Printf("Error parsing base URL: %v\n", err)
+		return
+	}
+
 	// Convert map to slice of structs for sorting
 	var pageList []Page
-	for url, count := range pages {
-		// Reconstruct full URL from normalized URL
-		fullURL := "https://" + url
+	for normalizedURL, count := range pages {
+		// Reconstruct full URL from normalized URL using original scheme
+		fullURL := parsedBaseURL.Scheme + "://" + normalizedURL
 		pageList = append(pageList, Page{URL: fullURL, Count: count})
 	}
 

--- a/main.go
+++ b/main.go
@@ -22,10 +22,7 @@ func printReport(pages map[string]int, baseURL string) {
 	fmt.Printf("  REPORT for %s\n", baseURL)
 	fmt.Println("=============================")
 
-	// Parse the baseURL to get the original scheme
-	parsedBaseURL, err := url.Parse(baseURL)
-	if err != nil {
-		fmt.Printf("Error parsing base URL: %v\n", err)
+		fmt.Printf("Failed to generate report - invalid base URL %s: %v\n", baseURL, err)
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -4,9 +4,45 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"sync"
 )
+
+// Page represents a page with its URL and count for sorting
+type Page struct {
+	URL   string
+	Count int
+}
+
+// printReport sorts and prints the crawl results in a formatted report
+func printReport(pages map[string]int, baseURL string) {
+	fmt.Println()
+	fmt.Println("=============================")
+	fmt.Printf("  REPORT for %s\n", baseURL)
+	fmt.Println("=============================")
+
+	// Convert map to slice of structs for sorting
+	var pageList []Page
+	for url, count := range pages {
+		// Reconstruct full URL from normalized URL
+		fullURL := "https://" + url
+		pageList = append(pageList, Page{URL: fullURL, Count: count})
+	}
+
+	// Sort by count (descending), then by URL (ascending) for ties
+	sort.Slice(pageList, func(i, j int) bool {
+		if pageList[i].Count != pageList[j].Count {
+			return pageList[i].Count > pageList[j].Count // Higher counts first
+		}
+		return pageList[i].URL < pageList[j].URL // Alphabetical for ties
+	})
+
+	// Print each page
+	for _, page := range pageList {
+		fmt.Printf("Found %d internal links to %s\n", page.Count, page.URL)
+	}
+}
 
 func main() {
 	// Get command line arguments (excluding program name)
@@ -102,9 +138,6 @@ func main() {
 	// Wait for all goroutines to complete
 	cfg.wg.Wait()
 
-	// Print the results
-	fmt.Println("\n=== Crawl Results ===")
-	for url, count := range cfg.pages {
-		fmt.Printf("%s: %d\n", url, count)
-	}
+	// Print the formatted report
+	printReport(cfg.pages, baseURLString)
 }


### PR DESCRIPTION
This pull request refactors how crawl results are reported in `main.go` by introducing a formatted and sorted summary. Instead of printing raw counts per URL, the results are now presented in a clear, sorted report that highlights the most-linked internal pages.

Improvements to crawl result reporting:

* Added a new `Page` struct and a `printReport` function to format and sort crawl results by the number of internal links (descending), and alphabetically by URL for ties. This makes the report easier to read and analyze.
* Replaced the previous unsorted output in `main()` with a call to `printReport`, ensuring consistent and user-friendly reporting.… crawl results