### PR TITLE
Concurrent requests

### DIFF
--- a/crawl_page.go
+++ b/crawl_page.go
@@ -12,6 +12,7 @@ type config struct {
 	pages              map[string]int
 	baseURL            *url.URL
 	maxPages           int
+	batchSize          int
 	mu                 *sync.Mutex
 	concurrencyControl chan struct{}
 	wg                 *sync.WaitGroup
@@ -106,17 +107,17 @@ func (cfg *config) crawlPage(rawCurrentURL string) {
 	}
 
 	// Process URLs in batches to avoid creating too many goroutines at once
-	batchSize := 5
+	batchSize := cfg.batchSize
 	for i := 0; i < len(urls); i += batchSize {
 		end := i + batchSize
 		if end > len(urls) {
 			end = len(urls)
 		}
-		
+
 		// Process this batch of URLs
 		for j := i; j < end; j++ {
 			foundURL := urls[j]
-			
+
 			// Check context before starting new goroutine
 			select {
 			case <-cfg.ctx.Done():

--- a/crawl_page.go
+++ b/crawl_page.go
@@ -119,12 +119,16 @@ func (cfg *config) crawlPage(rawCurrentURL string) {
 		for j := i; j < end; j++ {
 			foundURL := urls[j]
 
+			// Add to WaitGroup first to avoid race condition
+			cfg.wg.Add(1)
+
 			// Check context before starting new goroutine
 			select {
 			case <-cfg.ctx.Done():
+				// Context cancelled, decrement WaitGroup and return
+				cfg.wg.Done()
 				return
 			default:
-				cfg.wg.Add(1)
 				go cfg.crawlPage(foundURL)
 			}
 		}

--- a/crawl_page.go
+++ b/crawl_page.go
@@ -42,10 +42,12 @@ func (cfg *config) addPageVisit(normalizedURL string) (isFirst bool, exceedsLimi
 
 // crawlPage recursively crawls pages starting from rawCurrentURL, staying within the same domain as baseURL
 func (cfg *config) crawlPage(rawCurrentURL string) {
+	// Ensure WaitGroup is always decremented exactly once
+	defer cfg.wg.Done()
+
 	// Check if context is cancelled
 	select {
 	case <-cfg.ctx.Done():
-		cfg.wg.Done()
 		return
 	default:
 	}
@@ -54,7 +56,6 @@ func (cfg *config) crawlPage(rawCurrentURL string) {
 	cfg.concurrencyControl <- struct{}{}
 	defer func() {
 		<-cfg.concurrencyControl
-		cfg.wg.Done()
 	}()
 
 	// Parse the current URL

--- a/crawl_page.go
+++ b/crawl_page.go
@@ -42,12 +42,10 @@ func (cfg *config) addPageVisit(normalizedURL string) (isFirst bool, exceedsLimi
 
 // crawlPage recursively crawls pages starting from rawCurrentURL, staying within the same domain as baseURL
 func (cfg *config) crawlPage(rawCurrentURL string) {
-	// Ensure WaitGroup is always decremented exactly once
-	defer cfg.wg.Done()
-
 	// Check if context is cancelled
 	select {
 	case <-cfg.ctx.Done():
+		cfg.wg.Done() // Decrement WaitGroup since we're not doing any work
 		return
 	default:
 	}
@@ -56,6 +54,7 @@ func (cfg *config) crawlPage(rawCurrentURL string) {
 	cfg.concurrencyControl <- struct{}{}
 	defer func() {
 		<-cfg.concurrencyControl
+		cfg.wg.Done() // Decrement WaitGroup after releasing concurrency control
 	}()
 
 	// Parse the current URL

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -22,7 +23,10 @@ func printReport(pages map[string]int, baseURL string) {
 	fmt.Printf("  REPORT for %s\n", baseURL)
 	fmt.Println("=============================")
 
-		fmt.Printf("Failed to generate report - invalid base URL %s: %v\n", baseURL, err)
+	// Parse the baseURL to get the original scheme
+	parsedBaseURL, err := url.Parse(baseURL)
+	if err != nil {
+		fmt.Printf("Error parsing base URL: %v\n", err)
 		return
 	}
 
@@ -133,6 +137,7 @@ func main() {
 		mu:                 &sync.Mutex{},
 		concurrencyControl: make(chan struct{}, maxConcurrency),
 		wg:                 &sync.WaitGroup{},
+		ctx:                context.Background(),
 	}
 
 	// Start crawling from the base URL

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -33,9 +34,22 @@ func printReport(pages map[string]int, baseURL string) {
 	// Convert map to slice of structs for sorting
 	var pageList []Page
 	for normalizedURL, count := range pages {
-		// Reconstruct full URL from normalized URL using original scheme
-		fullURL := parsedBaseURL.Scheme + "://" + normalizedURL
-		pageList = append(pageList, Page{URL: fullURL, Count: count})
+		// Reconstruct full URL from normalized URL using the parsed base URL
+		// Split normalized URL to get host and path
+		parts := strings.SplitN(normalizedURL, "/", 2)
+		host := parts[0]
+		path := ""
+		if len(parts) > 1 {
+			path = "/" + parts[1]
+		}
+		
+		// Create full URL using the original scheme and port from base URL
+		fullURL := &url.URL{
+			Scheme: parsedBaseURL.Scheme,
+			Host:   host,
+			Path:   path,
+		}
+		pageList = append(pageList, Page{URL: fullURL.String(), Count: count})
 	}
 
 	// Sort by count (descending), then by URL (ascending) for ties


### PR DESCRIPTION
This pull request introduces improved context management and concurrency control to the web crawler, making it more robust and efficient. The main changes include adding support for context cancellation and timeouts, optimizing HTTP client usage, and batching URL processing to avoid excessive goroutine creation.

**Context and concurrency improvements:**

* Added a `context.Context` field to the `config` struct and integrated context cancellation checks throughout the crawling logic to allow for graceful shutdowns and timeouts. (`crawl_page.go` [[1]](diffhunk://#diff-619d3eb74ab26a5942fe9eb87fa939fcdd6d9a114d002443c285930194d0635aR4-R8) [[2]](diffhunk://#diff-619d3eb74ab26a5942fe9eb87fa939fcdd6d9a114d002443c285930194d0635aR18) [[3]](diffhunk://#diff-619d3eb74ab26a5942fe9eb87fa939fcdd6d9a114d002443c285930194d0635aR44-R51)
* Implemented batching of URL processing in `crawlPage` to limit the number of concurrent goroutines, reducing resource exhaustion risks. (`crawl_page.go` [crawl_page.goL93-R130](diffhunk://#diff-619d3eb74ab26a5942fe9eb87fa939fcdd6d9a114d002443c285930194d0635aL93-R130))

**HTTP client and request handling enhancements:**

* Created a global, optimized HTTP client with connection pooling and timeouts for efficient concurrent requests. (`get_html.go` [get_html.goR4-R39](diffhunk://#diff-0f31da63322173b94b3a5ba6113f2633cf15c8408b25eb5e0f51c0292c5d378eR4-R39))
* Refactored HTML fetching logic to support context-based cancellation and timeouts, introducing `getHTMLWithContext`. (`get_html.go` [[1]](diffhunk://#diff-0f31da63322173b94b3a5ba6113f2633cf15c8408b25eb5e0f51c0292c5d378eR4-R39) `crawl_page.go` [[2]](diffhunk://#diff-619d3eb74ab26a5942fe9eb87fa939fcdd6d9a114d002443c285930194d0635aL79-R95)

**General code improvements:**

* Improved error handling and base URL parsing in the report generation function for better reliability. (`main.go` [main.goL25-R29](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L25-R29))
* Updated initialization in `main.go` to pass a context to the crawler configuration. (`main.go` [main.goR140](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R140))